### PR TITLE
Add driver name sync from headcount

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An automated system for managing driver records in Samsara Fleet Management via 
 
 - **Create new drivers** in Samsara from CSV data
 - **Update driver information** (phone, license, location tags)
+- **Sync updates with Headcount data** for phone, location, and email
 - **Deactivate drivers** with reasons
 - **Email reports** of all operations performed
 - **Error handling** and detailed logging
@@ -102,17 +103,20 @@ Claude Code can help you:
 
 ### Manual Run
 ```bash
-python main.py --csv input/new_hires_example.csv
+python main.py --csv input/new_hires_example.csv \
+  --headcount "Headcount Report.xlsx"
 ```
 
 ### Dry Run (Test Mode)
 ```bash
-python main.py --csv input/new_hires_example.csv --dry-run
+python main.py --csv input/new_hires_example.csv \
+  --headcount "Headcount Report.xlsx" --dry-run
 ```
 
 ### Validate CSV Only
 ```bash
-python main.py --csv input/new_hires_example.csv --validate-only
+python main.py --csv input/new_hires_example.csv \
+  --headcount "Headcount Report.xlsx" --validate-only
 ```
 
 ## Windows Task Scheduler Setup
@@ -125,7 +129,7 @@ python main.py --csv input/new_hires_example.csv --validate-only
 
 3. Configure the Action:
    - **Program/script**: `C:\Python39\python.exe` (your Python path)
-   - **Arguments**: `main.py --csv input/new_hires_example.csv`
+   - **Arguments**: `main.py --csv input/new_hires_example.csv --headcount "Headcount Report.xlsx"`
    - **Start in**: `C:\path\to\samsara-fleet-manager`
 
 4. Additional Settings:

--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ DATA_DIR = os.getenv('DATA_DIR', './data')
 LOG_DIR = os.getenv('LOG_DIR', './logs')
 MAPPINGS_DIR = os.getenv('MAPPINGS_DIR', './mappings')
 USERNAMES_FILE = os.getenv('USERNAMES_FILE', './usernames.csv')
+HEADCOUNT_FILE = os.getenv('HEADCOUNT_FILE', 'Headcount Report.xlsx')
 
 # Operational settings
 DRY_RUN_DEFAULT = os.getenv('DRY_RUN_DEFAULT', 'False').lower() == 'true'

--- a/headcount_loader.py
+++ b/headcount_loader.py
@@ -1,0 +1,99 @@
+import pandas as pd
+from typing import Dict, Optional
+import math
+
+
+def load_headcount_data(
+    xlsx_path: str,
+    *,
+    locations_csv: str = "locations.csv",
+    payroll_id_column: Optional[str] = None,
+) -> Dict[str, Dict[str, Optional[str]]]:
+    """Load headcount data from an Excel spreadsheet.
+
+    The resulting mapping is keyed by payroll ID and provides the
+    driver's name, email, phone number, and a location tag ID when
+    available.
+    """
+    df = pd.read_excel(xlsx_path)
+    df.columns = [str(c).strip() for c in df.columns]
+
+    # Discover payroll ID column if not provided
+    if payroll_id_column and payroll_id_column in df.columns:
+        id_col = payroll_id_column
+    else:
+        id_col = None
+        for col in [
+            "Payroll_ID",
+            "Payroll ID",
+            "Employee_ID",
+            "Employee ID",
+            "Route#",
+        ]:
+            if col in df.columns:
+                id_col = col
+                break
+    if not id_col:
+        raise ValueError("Payroll ID column not found in spreadsheet")
+
+    email_col = "Work_Email" if "Work_Email" in df.columns else "Email"
+    phone_col = "Primary_Phone" if "Primary_Phone" in df.columns else "Phone"
+    first_col = "Legal_Firstname" if "Legal_Firstname" in df.columns else None
+    last_col = "Legal_Lastname" if "Legal_Lastname" in df.columns else None
+
+    location_col = None
+    for col in ["Work_Location", "Location_Code", "Location_Desc", "Location"]:
+        if col in df.columns:
+            location_col = col
+            break
+
+    loc_map = {}
+    try:
+        loc_df = pd.read_csv(locations_csv)
+        for _, row in loc_df.iterrows():
+            loc_map[str(row["location"]).strip()] = str(row["id"])
+    except FileNotFoundError:
+        pass
+
+    mapping: Dict[str, Dict[str, Optional[str]]] = {}
+    for _, row in df.iterrows():
+        pid = row.get(id_col)
+        if pd.isna(pid):
+            continue
+        if isinstance(pid, float) and math.isclose(pid % 1, 0):
+            pid = int(pid)
+        pid_str = str(pid)
+
+        email = row.get(email_col)
+        if pd.isna(email):
+            email = None
+        else:
+            email = str(email).strip()
+
+        phone = row.get(phone_col)
+        if pd.isna(phone):
+            phone = None
+        else:
+            phone = str(int(phone)) if isinstance(phone, float) else str(phone).strip()
+
+        loc_tag = None
+        if location_col:
+            loc_val = row.get(location_col)
+            if not pd.isna(loc_val):
+                loc_tag = loc_map.get(str(loc_val).strip())
+
+        name = None
+        if first_col and last_col:
+            first = row.get(first_col)
+            last = row.get(last_col)
+            if not pd.isna(first) and not pd.isna(last):
+                name = f"{str(first).strip()} {str(last).strip()}"
+
+        mapping[pid_str] = {
+            "name": name,
+            "email": email,
+            "phone": phone,
+            "location_tag_id": loc_tag,
+        }
+
+    return mapping

--- a/tests/test_headcount_loader.py
+++ b/tests/test_headcount_loader.py
@@ -1,0 +1,12 @@
+import headcount_loader
+
+
+def test_load_headcount_data():
+    mapping = headcount_loader.load_headcount_data("Headcount Report.xlsx")
+    # Known first row values from the sample file
+    info = mapping.get("613")
+    assert info
+    assert info["name"] == "SAMUEL ABASCAL"
+    assert info["email"] == "sabascal@chaparraldist.com"
+    assert info["phone"].startswith("151266")
+    assert info["location_tag_id"] == "2762148"


### PR DESCRIPTION
## Summary
- include driver name in headcount data
- merge name from headcount when processing CSVs
- update create/update logic to handle merged names
- extend unit tests
- add command-line flag for headcount file so updates can automatically merge data

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68890d92774083288855289079c9fb60