### PR TITLE
Fix headcount loader locations path

### DIFF
--- a/driver_manager.py
+++ b/driver_manager.py
@@ -6,7 +6,7 @@ Handles business logic for driver operations using Samsara API
 import logging
 import csv
 from typing import Dict, List, Set
-from datetime import datetime, timezone
+from datetime import datetime
 import json
 from pathlib import Path
 

--- a/headcount_loader.py
+++ b/headcount_loader.py
@@ -1,12 +1,14 @@
 import pandas as pd
 from typing import Dict, Optional
 import math
+from pathlib import Path
+import config
 
 
 def load_headcount_data(
     xlsx_path: str,
     *,
-    locations_csv: str = "locations.csv",
+    locations_csv: Path = Path(config.MAPPINGS_DIR) / "locations.csv",
     payroll_id_column: Optional[str] = None,
 ) -> Dict[str, Dict[str, Optional[str]]]:
     """Load headcount data from an Excel spreadsheet.


### PR DESCRIPTION
## Summary
- default `locations_csv` to the mappings directory
- drop unused import from `driver_manager.py`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889320623108328ad997ab4d881e7f8