### PR TITLE
Send operations report only when operations occur

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,8 +102,11 @@ def main() -> int:
     )
     stats = manager.get_summary_stats()
 
-    reporter = build_email_reporter()
-    reporter.send_operations_report(operations, stats)
+    if sum(stats.values()) > 0:
+        reporter = build_email_reporter()
+        reporter.send_operations_report(operations, stats)
+    else:
+        logging.info("No operations performed; skipping report")
     return 0
 
 


### PR DESCRIPTION
## Summary
- skip sending operations report when no operations were performed

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cc893bbcc83289863246643e39c13