### PR TITLE
Add Black to development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 ruff
 python-dotenv
+black==24.4.2


### PR DESCRIPTION
## Summary
- add `black==24.4.2` to development requirements

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688ce22d43e8832883333a948d4a1ea0