### PR TITLE
ci: install from requirements files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install
-        run: pip install -e .[dev]
+        run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Ruff
         run: ruff check --output-format=github .
       - name: Black


### PR DESCRIPTION
## Summary
- install dependencies from requirements files in CI

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement pywin32)*
- `ruff check --output-format=github .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ce4464c508328b0c60813579793ef