### PR TITLE
chore: target Python 3.11 for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ samsara-driver-sync = "main:cli_entry"
 
 [tool.black]
 line-length = 88
+target-version = ["py311"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Summary
- specify Python 3.11 as target version for Black formatter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ce4498efc8328bec5467e3ba7e66f